### PR TITLE
Can optionally document members listed in __all__

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -49,6 +49,8 @@ There are a few config values you can set. The only necessary one is the srcdir:
                             Defaults to True.
   :jinjaapi_addsummarytemplate: :class:`bool` - If True, add autosummary template for classes.
                                 Defaults to True.
+  :jinjaapi_include_from_all: :class:`bool` - If True, include members of a module or package that are listed in `__all__`.
+                                Defaults to True.
 
 Documenter
 ----------

--- a/src/jinjaapidoc/__init__.py
+++ b/src/jinjaapidoc/__init__.py
@@ -37,5 +37,6 @@ def setup(app):
     app.add_config_value('jinjaapi_dryrun', False, 'env')
     app.add_config_value('jinjaapi_includeprivate', True, 'env')
     app.add_config_value('jinjaapi_addsummarytemplate', True, 'env')
+    app.add_config_value('jinjaapi_include_from_all', True, 'env')
 
     return {'version': __version__, 'parallel_read_safe': True}


### PR DESCRIPTION
The current behaviour of jinjaapidoc is to document the member of a module or package, only if the member was declared in the module or package.
This pull request adds the ability for jinjaapidoc to be able to document a member also if it is listed in the `__all__` attribute of the module or package. This behaviour is turned on by default but can be disabled with the new `jinjaapi_include_from_all` configuration variable.

Closes #8 
